### PR TITLE
Fixes for the packageFile option returning a boolean, and an incorrect exit code being returned on exit.

### DIFF
--- a/bin/dep-validate
+++ b/bin/dep-validate
@@ -24,7 +24,7 @@ cli
   .option('--hardcoded [value]', 'validate against hardcoded versions or not', hardcoded, undefined)
   .option('-e, --exclude [value]', 'ependencies to exclude from validation', collect, undefined)
   .option('-o, --only [value]', 'only use production or development dependencies', collect, undefined)
-  .option('-p, --packageFile', 'path to a package file to validate', undefined, undefined)
+  .option('-p, --packageFile [file]', 'path to a package file to validate', undefined, undefined)
   .parse(process.argv);
 
 // validate using the provided options
@@ -45,4 +45,4 @@ var hasErrors = dv
 hasErrors && dv.log(results);
 
 // exit with error codes as needed
-process.exit(+!hasErrors);
+process.exit(+(hasErrors !== 0));


### PR DESCRIPTION
Having the option set for just `'-p, --packageFile'` will only return a true/false response for the option, making the require throw an error.
Also, the `hasErrors` function returns a value rather than a boolean of the existence of an error, so the current bin would return 1 when there were no errors, and 0 when there were.