### PR TITLE
Update dependencies to fix npm audit founds

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   ],
   "scripts": {},
   "dependencies": {
-    "cli-table2": "^0.2.0",
-    "commander": "^2.9.0",
+    "cli-table3": "^0.5.1",
+    "commander": "^2.19.0",
     "gulp-util": "^3.0.8",
     "package": "^1.0.1",
     "through": "^2.3.8"


### PR DESCRIPTION
`npm audit` is showing a low from a dependency in `cli-table2`. It appears that isn't being maintained any more, whereas the `cli-table3` fork is, so I've replaced it with that.